### PR TITLE
manually shutdown instead of halt api

### DIFF
--- a/vultr/step_shutdown.go
+++ b/vultr/step_shutdown.go
@@ -19,27 +19,28 @@ type stepShutdown struct {
 }
 
 func (s *stepShutdown) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	c := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
-
 	ui.Say("Performing graceful shutdown...")
 	time.Sleep(ShutdownDelaySec * time.Second)
-	id := state.Get("server_id").(string)
-	ui.Say("Performing graceful shutdown...")
 
-	err := s.client.Server.Halt(context.Background(), id)
+	comm := state.Get("communicator").(packer.Communicator)
 
-	if err != nil {
+	cmd := &packer.RemoteCmd{
+		Command: "shutdown -P now",
+	}
+
+	if err := comm.Start(ctx, cmd); err != nil {
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
+	cmd.Wait()
 
-	err = waitForServerState("active", "stopped", id, s.client, c.stateTimeout)
-	if err != nil {
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
+	if cmd.ExitStatus() == packer.CmdDisconnect {
+		ui.Say("Server successfully shutdown")
+		time.Sleep(ShutdownDelaySec * time.Second)
+	} else {
+		ui.Say("Sleeping to ensure that server is shut down...")
 	}
 
 	return multistep.ActionContinue


### PR DESCRIPTION


## Description
Looks like the Vultr Halt API is not doing a clean shutdown. Its causing issues during some packer builds so we are going back to manually `shutdown -p now` command

## Related Issues
none

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
