### PR TITLE
Updated documentation for state_timeout

### DIFF
--- a/website/source/docs/builders/vultr.html.md
+++ b/website/source/docs/builders/vultr.html.md
@@ -71,6 +71,8 @@ builder.
 
 -   `tag` (string) - The tag to assign to this server.
 
+-   `state_timeout` (string) - A duration to wait for the instance to boot or a snapshot to be taken. Must be a string in [golang Duration-parsable format](https://golang.org/pkg/time/#ParseDuration), like "10m" or "30s". 
+
 ## Basic Example
 
 Here is a Vultr builder example. The vultr_api_key should be replaced with an actual Vultr API Key
@@ -87,6 +89,6 @@ Here is a Vultr builder example. The vultr_api_key should be replaced with an ac
         "plan_id": 402,
         "os_id": 127,
         "ssh_username": "root",
-        "stateTimeout": 100
+        "state_timeout": "15m"
     }],
 ```


### PR DESCRIPTION
When trying to use this builder, I found I was running into timeouts when taking the final snapshot. I noticed the "stateTimeout" in the example had the wrong key name, the wrong example value, and wasn't documented.

I dug into the source, and found the config that worked, and by setting the timeout to 15m was able to get a snapshot. I've updated the documentation to reflect the correct values.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you successfully ran tests with your changes locally?
