### PR TITLE
missing defer on f.close

### DIFF
--- a/vultr/step_create_ssh_key.go
+++ b/vultr/step_create_ssh_key.go
@@ -82,7 +82,7 @@ func (s *stepCreateSSHKey) Run(_ context.Context, state multistep.StateBag) mult
 
 		// Write out the key
 		err = pem.Encode(f, &privBlk)
-		f.Close()
+		defer f.Close()
 		if err != nil {
 			state.Put("error", fmt.Errorf("Error saving debug key: %s", err))
 			return multistep.ActionHalt


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Missing defer on `f.close` which was causing further checks to fail.

## Related Issues
Fixes #76 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
