### PR TITLE
Fix for v2 instance creation types

### DIFF
--- a/vultr/builder_test.go
+++ b/vultr/builder_test.go
@@ -98,7 +98,7 @@ func TestBuilderPrepare_OSID(t *testing.T) {
 	if len(warnings) > 0 {
 		t.Fatalf("bad: %#v", warnings)
 	}
-	if err == nil {
+	if err != nil {
 		t.Fatalf("should error")
 	}
 

--- a/vultr/config.go
+++ b/vultr/config.go
@@ -97,21 +97,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		errs = packer.MultiErrorAppend(errs, errors.New("you can only set one of the following: `app_id`, `snapshot_id`, `iso_id`"))
 	}
 
-	if c.AppID != 0 {
-		c.OSID = AppOSID
-	}
-	if c.SnapshotID != "" {
-		c.OSID = SnapshotOSID
-	}
-	if c.ISOID != "" {
-		c.OSID = CustomOSID
-	}
-
-	if c.OSID == 0 {
-		errs = packer.MultiErrorAppend(errs, errors.New("os_id is required"))
-	}
-
-	if (c.OSID == SnapshotOSID || c.OSID == CustomOSID) && c.Comm.SSHPassword == "" && c.Comm.SSHPrivateKeyFile == "" {
+	if (c.SnapshotID != "" || c.ISOID != "") && c.Comm.SSHPassword == "" && c.Comm.SSHPrivateKeyFile == "" {
 		errs = packer.MultiErrorAppend(errs, errors.New("either `ssh_password` or `ssh_private_key_file` must be defined for snapshot or custom OS"))
 	}
 

--- a/vultr/step_create_server.go
+++ b/vultr/step_create_server.go
@@ -41,7 +41,7 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 		Hostname:             c.Hostname,
 		Tag:                  c.Tag,
 	}
-	ui.Say(fmt.Sprintf("%v", instanceReq))
+
 	instance, err := s.client.Instance.Create(ctx, instanceReq)
 	if err != nil {
 		err = errors.New("Error creating server: " + err.Error())

--- a/website/source/docs/builders/vultr.html.md
+++ b/website/source/docs/builders/vultr.html.md
@@ -35,11 +35,10 @@ In addition to the options listed here, a
 [communicator](https://www.packer.io/docs/communicators) can be configured for this
 builder.
 
+**NOTE**: that  `os_id`, `app_id`, `snapshot_id`, or `iso_id` are not required and are optional. You **must** supply at least one for instance creation.
 ### Required:
 
 -   `api_key` (string) - The Vultr API Key to access your account.
-
--   `os_id` (int) - The id of the os to use. This will be the OS that will be used to launch a new instance and provision it. See [List Operating Systems](https://www.vultr.com/api/v2/#operation/list-os).
 
 -   `region_id` (string) - The id of the region to launch the instance in. See [List Regions](https://www.vultr.com/api/v2/#operation/list-regions).
     
@@ -47,13 +46,15 @@ builder.
 
 ### Optional:
 
+-   `os_id` (int) - The id of the os to use. This will be the OS that will be used to launch a new instance and provision it. See [List Operating Systems](https://www.vultr.com/api/v2/#operation/list-os).
+
 -   `snapshot_description` (string) - Description of the snapshot.
 
--   `snapshot_id` (string) -   If you've selected the 'snapshot' (OS 164) operating system, this should be the ID of the snapshot. See [Snapshot](https://www.vultr.com/api/v2/#operation/list-snapshots).
+-   `snapshot_id` (string) -   If you've selected the 'snapshot' operating system, this should be the ID of the snapshot. See [Snapshot](https://www.vultr.com/api/v2/#operation/list-snapshots).
 
--   `iso_id` (string) - If you've selected the 'custom' (OS 159) operating system, this is the ID of a specific ISO to mount during the deployment. See [ISO](https://www.vultr.com/api/v2/#operation/list-isos).
+-   `iso_id` (string) - If you've selected the 'custom' operating system, this is the ID of a specific ISO to mount during the deployment. See [ISO](https://www.vultr.com/api/v2/#operation/list-isos).
 
--   `app_id` (int) - If launching an application (OSID 186), this is the ID to launch. See [App](https://www.vultr.com/api/v2/#operation/list-applications).
+-   `app_id` (int) - If launching an application, this is the ID to launch. See [App](https://www.vultr.com/api/v2/#operation/list-applications).
 
 -   `enable_ipv6` (bool) - IPv6 subnet will be assigned to the machine.
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
With API v2 there was a change that no longer requires the passing of `os_id` with `snapshot`, `app`, or `iso`.

Packer was still adding in the corresponding `os_id` with the other types so this PR will remove that.

I tested creation of snapshot, app, os, and iso independently. @Oogy you mind going through these builds also. 

## Related Issues
fixes #105 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
